### PR TITLE
adds links to nttw

### DIFF
--- a/notimetowait.md
+++ b/notimetowait.md
@@ -27,20 +27,73 @@ Developers (people who design the formats) &#43;
 Open Standards Working Group (people who write specification for formats)
 
 Together!
- 
+
  ----------
 
-## What 
+## What
 A FREE three day symposium focused on Matroska and FFV1 for use in digital audiovisual preservation hosted by [Deutsche Kinemathek](https://www.deutsche-kinemathek.de/), [Zuse Institute Berlin](http://www.zib.de/) and [MediaArea.net](https://mediaarea.net/en/MediaInfo). The event will feature talks, presentations, and working meetings on Matroska, FFV1, and the software, documentation, and use cases associated with these formats. The event will also present on the current state of the IETF’s [CELLAR](https://datatracker.ietf.org/wg/cellar/charter/) working group’s progress to develop specifications for Matroska and FFV1 as well as efforts to design and extend software in support of these formats. This event provides an opportunity for format inventors, developers, specification authors, and archivists to collaborate and advance audiovisual preservation formats.
+
+## Presentations
+
+Day 1
+
+* Introduction: Volkmar Ernst & Jürgen Keiper, Ashley Blewer & Dave Rice [video](https://www.youtube.com/watch?v=1jL3-6tNVv0)
+* PREFORMA Challenge, Erwin Verbruggen [video](https://www.youtube.com/watch?v=m5-ommDV9Ac) / [slides](https://github.com/preforma/notimetowait/blob/master/presentations/20160718_berlin_preforma_pdfwithnotes.pdf)
+* "FFV1 and Archives: A Short History About Almost Everything", Peter Bubestinger [video](https://www.youtube.com/watch?v=qPVnSF0oENM) / [slides](https://github.com/preforma/notimetowait/blob/master/presentations/20160718-NoTimeToWait_Symposium.zip)
+* Matroska: A History, Steve Lhomme [video](https://www.youtube.com/watch?v=UTFsTqXJBHs) / [slides](https://github.com/preforma/notimetowait/blob/master/presentations/A%20History.odp)
+* More Than Just a Wrapper: The Role of Container Formats within Archive Workflows, Tobias Rapp (NOA GmbH) [video](https://www.youtube.com/watch?v=22gLfOA47vU) [slides](https://github.com/preforma/notimetowait/blob/master/presentations/ContainerFormatRole.pdf)
+* CELLAR Working Group Update, Tessa Fallon [video](https://www.youtube.com/watch?v=rlMOh5SEpVY)
+* Developing Specifications for Audiovisual Preservation and Archiving: Lessons from FADGI's MXF AS-07, Kate Murray (Library of Congress) [video](https://www.youtube.com/watch?v=O8uFQXvvAEE) / [slides](https://github.com/preforma/notimetowait/blob/master/presentations/NoTimeToWait2016-MurrayAS07-public.pptx)
+* Matroska, webM, and Google, Michael Bradshaw [blog](http://youtube-eng.blogspot.de/2016/04/a-look-into-youtubes-video-file-anatomy.html)
+* Comparison of Lossless Video Codecs for Digital Preservation, Merle Friedrichsen (Technische Informationsbibliothek) [video](https://www.youtube.com/watch?v=GGomd2vqUuU) / [slides](https://github.com/preforma/notimetowait/blob/master/presentations/LightningTalk_Friedrichsen.pdf)
+* 5 years of archiving with FFV1 at the Austrian Mediathek, Marion Jaks (Österreichische Mediathek) [video](https://www.youtube.com/watch?v=1KswtZpaBJw)
+* DVA-Profession: one of the very view workflow management systems dealing with ffv1, Hermann Lewetz (Österreichische Mediathek) [video](https://www.youtube.com/watch?v=qeTl8C_JIbk)
+* Implementing FFV1 for Large-Scale A/V Digitization at IU, Heidi Dowding (Indiana University) [video](https://www.youtube.com/watch?v=l570RIoagFA)
+* The Moral Character of Software, Igor [video](https://www.youtube.com/watch?v=8cKWe5ojKyQ)
+* OpenArchive Intro - OSS mobile media preservation + future application, Natalie Cadranel (no video upon request) [website](https://open-archive.net/)
+* FFV1 and DPX, Kieran O'Leary (IFI Irish Film Archive) & Reto Kromer (AV Preservation by reto.ch) [video](https://www.youtube.com/watch?v=q54_FirxdX8)
+
+Day 3
+
+* Intro and IETF Report Back, Jerome Martinez, Steve Lhomme, Dave Rice [video](https://www.youtube.com/watch?v=1n9J-LaCVU0)
+* Stress testing FFV1, Kieran Kunyha [video](https://www.youtube.com/watch?v=uCW0hWlSsg8)
+* Stress testing FFV1, Peter Bubestinger [video](https://www.youtube.com/watch?v=_ogZ9t8vINM)
+* FFV1 and Matroska: Digitization and Contextualization, Dave Rice [video](https://youtu.be/yuT6PLDfQw4)
+* MediaConch: Presentation of Specification-Based Validation, Jerome Martinez [video](https://www.youtube.com/watch?v=QhaJb_OIAP4)
+* Matroska Tools, Steve Lhomme [video](https://www.youtube.com/watch?v=SJ8EdRqZbFM)
+* Audiovisual Archiving in the Balkans - A Survey (Technological issues and challenges), Daniel Borosa (Croatian Radiotelevision) (no video upon request) [slides](https://github.com/preforma/notimetowait/blob/master/presentations/Presentation%20Borosa-%20MKV%20Berlin%202016.ppsx)
+* When Vendors Say No: A vendor wouldn't implement FFV1/MKV and how this decision transformed our archive, Kieran O'Leary (IFI Irish Film Archive) [video](https://www.youtube.com/watch?v=DgRc-A1hkVg)
+
+## Working group documents (Day 2)
+
+* [Matroska](https://docs.google.com/document/d/1dkT5cpUWFWXKHXC1132d1ndmwrnVPV7nBeyHAehM5HQ/edit)
+* [FFV1](https://docs.google.com/document/d/1lCJ5JRcGdjLvjG6vSZbRL_RnnCX_D_x2rwN57PvbY3s/edit?ts=578dffe5)
+* [Preservation](https://docs.google.com/document/d/1omcIEYAA5dpI3xBpxRYX13M1e7PL_2HmFSjaC0rpSZA/edit#)
+
+## Reports
+
+* [Report on MediaConch blog](https://mediaarea.net/MediaConch/2016/07/26/No-Time-To-Wait-Preservation-FFV1-Matroska-Symposium/)
+* [Report on Beeld en Geluid blog](http://www.beeldengeluid.nl/en/blogs/research-amp-development-en/201607/tools-trade)
+* [Twitter Storify](https://storify.com/ablwr/no-time-to-wait)
+
+## Streaming  
+
+To stream and record this conference, we used:
+* Mac laptop
+* BlackMagic Design UltraStudio Express (thunderbolt)
+* Small handheld consumer camera
+* Tripod for camera
+* [Open Broadcaster Software](https://obsproject.com/)
+* YouTube (for streaming and uploaded recorded media)
+* For one video ("FFV1 and Matroska: Digitization and Contextualization"), we recorded using an iPhone 6S
 
 ## When
  Monday, July 18, 2016 - Wednesday, July 20, 2016
 
-
 ## Where
 [Deutsche Kinemathek – Museum für Film und Fernsehen](https://www.deutsche-kinemathek.de/)  
 
-<img src="https://upload.wikimedia.org/wikipedia/commons/thumb/9/91/Deutsche_Kinemathek_2.jpg/3264px-Deutsche_Kinemathek_2.jpg" width="500" > 
+<img src="https://upload.wikimedia.org/wikipedia/commons/thumb/9/91/Deutsche_Kinemathek_2.jpg/3264px-Deutsche_Kinemathek_2.jpg" width="500" >
 <br>
 The Deutsche Kinemathek – Museum für Film und Fernsehen, Wikimedia Commons
 
@@ -55,19 +108,6 @@ The Zuse Institute Berlin, Wikimedia Commons
 [Takustraße 7, 14195 Berlin](https://www.google.com/maps/place/Konrad-Zuse-Zentrum+f%C3%BCr+Informationstechnik+Berlin/@52.4561009,13.2959837,17z/data=!3m1!4b1!4m5!3m4!1s0x47a85a657d4919af:0x46163d5d4c3fc235!8m2!3d52.4561009!4d13.2981777)
 
 \*Parts of the workshop will also be accessible remotely
-
-**Registration:** 
-Registration is now closed, as we have reached capacity. If you are still interested in attending, you may sign up via the [waiting list form](https://docs.google.com/forms/d/1ic3LVh1xBZGuzIXSFbczIRcRHNAox3cbi2RDHzY8doo/edit?usp=drive_web) (it’s free!).
-
-**Hotel:** We recommend nearby Motel One. [Hotel Website](http://www.motel-one.com/en/hotels/berlin/berlin-potsdamer-platz) [Map](https://www.google.com/maps/place/Hotel+Motel+One+Berlin+Potsdamer+Platz/@52.5100019,13.3787898,17z/data=!3m2!4b1!5s0x47a851cf0179e5fb:0xa25540743a8a2f04!4m5!3m4!1s0x47a851cee52096a7:0xc859a1be3c2f2346!8m2!3d52.5099987!4d13.3809785)
- 
-## Schedule 
-
-To view a more comprehensive schedule, please [click here](https://docs.google.com/spreadsheets/d/1XRgwKwF6Y2LPy5h-peCag9knn4WZcehI9TI9Qs9a9i4/edit?usp=sharing)
-
-To sign up to give a lightning talk or a workshop/demonstration, please [click here](https://docs.google.com/spreadsheets/d/1U1USrEpG1QjC_1hBEYRRLTtrMsfHrY4vcKxAH3o_8M8/edit?usp=sharing)
-
-The schedule of the event is under development, if you have an idea for the agenda item or presentation on FFV1 and/or Matroska or audiovisual digital preservation, please feel welcome to contact [info@mediaarea.net](mailto:info@mediaarea.net) for your ideas or share thoughts via comments on our working document.
 
 \* Event title inspiration from [https://blogs.loc.gov/digitalpreservation/2014/12/comparing-formats-for-video-digitization/](https://blogs.loc.gov/digitalpreservation/2014/12/comparing-formats-for-video-digitization/)
 


### PR DESCRIPTION
This adds links to slides and video from the original NTTW. 

BTW if you migrate slides from the Preforma repo onto MediaArea, I can update the links. But since that doesn't exist right now, I copied as is.

I'll follow this pattern for NTTW2 when slides are accumulated and added.